### PR TITLE
v0.1.5

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,10 @@ Options:
   -d, --default             Run with default options
   -p, --path <path>         Directory to analyze (default: ./)
   -c, --config <path>       Configuration file name (default: .env.local)
+  -a, --all                 Include commented environment variables
 ```
+
+> chkenv does not check commented environment variables by default. If you want to include them, then use `-a` or `--all` flag.
 
 ### Examples
 
@@ -54,7 +57,7 @@ Enter the directory to analyze (default: ./):
 Enter the configuration file name (default: .env.local):
 ```
 
-2. You can use the -d or --default flag for defaults i.e `./` and `.env.local` -
+2. You can use the -d or --default flag for defaults i.e `./` and `.env.local` and ignore commented environment variables -
 
 ```bash
 chkenv -d
@@ -76,6 +79,12 @@ chkenv --path src/app
 
 ```bash
 chkenv --config .env.production --path src/app
+```
+
+6. Include commented environment variables:
+
+```bash
+chkenv --all
 ```
 
 ### Output Example
@@ -103,6 +112,8 @@ chkenv --config .env.production --path src/app
 - `.jsx`
 - `.ts`
 - `.tsx`
+- `.mjs`
+- `.cjs`
 
 ## Excluded Directories
 
@@ -115,6 +126,10 @@ chkenv --config .env.production --path src/app
 - `.cache`
 - `public`
 - `.vscode`
+- `.turbo`
+- `logs`
+- `.idea`
+- `.expo`
 
 ## Contributing
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chkenv",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Check environment variables",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{md,yaml,js,jsx,json,mjs,css}\""
+    "format": "prettier --write \"**/*.{md,mdx,yaml,js,jsx,json,mjs,css}\""
   },
   "devDependencies": {
     "prettier": "^3.2.5",

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -2,5 +2,5 @@ import { getMDXPage } from "@/lib/mdx";
 
 export default async function Page() {
   const page = await getMDXPage("index");
-  return <main className="leading-7 space-y-6 sm:space-y-8">{page.mdxContent}</main>;
+  return <main className="leading-7 space-y-6 sm:space-y-8">{page}</main>;
 }

--- a/www/docs/index.mdx
+++ b/www/docs/index.mdx
@@ -39,7 +39,10 @@ Options:
   -d, --default             Run with default options
   -p, --path <path>         Directory to analyze (default: ./)
   -c, --config <path>       Configuration file name (default: .env.local)
+  -a, --all                 Include commented environment variables
 ```
+
+> chkenv does not check commented environment variables by default. If you want to include them, then use `-a` or `--all` flag.
 
 ### Output Example
 
@@ -69,6 +72,8 @@ Enter the configuration file name (default: .env.local):
 - `.jsx`
 - `.ts`
 - `.tsx`
+- `.mjs`
+- `.cjs`
 
 ## Excluded Directories
 
@@ -81,6 +86,10 @@ Enter the configuration file name (default: .env.local):
 - `.cache`
 - `public`
 - `.vscode`
+- `.turbo`
+- `logs`
+- `.idea`
+- `.expo`
 
 ## Contributing
 

--- a/www/lib/mdx.ts
+++ b/www/lib/mdx.ts
@@ -5,7 +5,6 @@ import rehypePrettyCode from "rehype-pretty-code";
 import { compileMDX } from "next-mdx-remote/rsc";
 
 import components from "@/components/mdx";
-import { FrontMatter } from "@/types/mdx";
 
 const ROOT = path.join(process.cwd(), "docs");
 
@@ -13,11 +12,10 @@ export async function getMDXPage(slug: string) {
   const fullPath = path.join(ROOT, `${slug}.mdx`);
   const fileContent = fs.readFileSync(fullPath, "utf8");
 
-  const { content, frontmatter } = await compileMDX({
+  const { content } = await compileMDX({
     source: fileContent,
     components,
     options: {
-      parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGfm],
         rehypePlugins: [
@@ -30,11 +28,5 @@ export async function getMDXPage(slug: string) {
     },
   });
 
-  return {
-    mdxContent: content,
-    meta: {
-      ...frontmatter,
-      slug,
-    } as FrontMatter,
-  };
+  return content;
 }

--- a/www/types/mdx.ts
+++ b/www/types/mdx.ts
@@ -1,31 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MDX = React.ReactElement<any, string | React.JSXElementConstructor<any>>;
-
-export type ContentType = "blog" | "interaction";
-
-type FrontMatter = {
-  title: string;
-  description: string;
-  date: string;
-  slug: string;
-  keywords: string[];
-  type: ContentType;
-};
-
-type Content = {
-  mdxContent: MDX;
-  meta: FrontMatter;
-};
-
-type HeadingProps = React.DetailedHTMLProps<
+export type HeadingProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLHeadingElement>,
   HTMLHeadingElement
 >;
-
-type PageContent = {
-  current: Content;
-  previous: Content | null;
-  next: Content | null;
-};
-
-export type { FrontMatter, Content, MDX, PageContent, HeadingProps };


### PR DESCRIPTION
CLI -

- Ignore whitespace in env configuration file
- Ignore commented envs by default, you can use `-a` or `--all` flag to include them
- Added few `EXCLUDE_DIRS` and `INCLUDE_EXTENSIONS`

WWW -

- Remove unused types (I initially copied it all from my existing website's codebase, cause I was in a hurry)
- Refactored MDX parser a little for simplicity
